### PR TITLE
Added a loading screen animation

### DIFF
--- a/new-game-project/Assets/Nodes/loading.tscn
+++ b/new-game-project/Assets/Nodes/loading.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=2 format=3 uid="uid://b8mf1xrjx5t6k"]
+
+[ext_resource type="Script" path="res://LoadingScreen.cs" id="1_gen5c"]
+
+[node name="Loading" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -3.0
+offset_top = -3.0
+offset_right = -3.0
+offset_bottom = -3.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_gen5c")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Control" type="Control" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/Control"]
+layout_mode = 0
+offset_left = 81.0
+offset_top = 62.0
+offset_right = 578.0
+offset_bottom = 426.0
+
+[node name="Loading" type="Label" parent="Panel/Control/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Loading..."
+
+[node name="LoadingBar" type="ProgressBar" parent="."]
+layout_mode = 1
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -27.0
+grow_horizontal = 2
+grow_vertical = 0

--- a/new-game-project/Assets/Scripts/LoadingScreen.cs
+++ b/new-game-project/Assets/Scripts/LoadingScreen.cs
@@ -1,0 +1,48 @@
+using Godot;
+using System;
+using System.IO;
+
+public partial class LoadingScreen : Control
+{
+	private string pathToScene;
+	private ProgressBar loading; 
+	private bool loadingNow;
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready() {
+		loading = GetNode<ProgressBar>("LoadingBar");
+	}
+
+	// Called every frame. 'delta' is the elapsed time since the previous frame.
+	public override void _Process(double delta) {
+		if (loadingNow == true) {
+			var loadingProgress = new Godot.Collections.Array();
+			var amountLoaded = ResourceLoader.LoadThreadedGetStatus(pathToScene, loadingProgress);
+			if (amountLoaded == ResourceLoader.ThreadLoadStatus.InProgress) {
+				GD.Print("Here");
+				loading.Value = Convert.ToDouble(loadingProgress[0]) * 100;
+			}
+			else if (amountLoaded == ResourceLoader.ThreadLoadStatus.Loaded) {
+				GD.Print("Yay");
+				loading.Value = 100;
+				loadingNow = false;
+			}
+		}
+		else {
+			if (Input.IsAnythingPressed()) {
+				enterScene();
+			}
+		}
+	}
+
+	public void loadScene(string path) {
+		Show();
+		pathToScene = path;
+		GD.Print("Hey");
+		ResourceLoader.LoadThreadedRequest(pathToScene);
+		loadingNow = true;
+	}
+
+	public void enterScene() {
+		GetTree().ChangeSceneToFile(pathToScene);
+	}
+}


### PR DESCRIPTION
Added a loading screen animation. Has a progress bar and waits for any user input to enter in to the new scene after it has been loaded. Will need to be added to nodes for all scenes that require a scene change.