### PR TITLE
Save User Settings Preferences

### DIFF
--- a/new-game-project/Assets/Nodes/settings_menu.tscn
+++ b/new-game-project/Assets/Nodes/settings_menu.tscn
@@ -26,7 +26,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Volume"
 
-[node name="Volume Control" type="HSlider" parent="MarginContainer/VBoxContainer"]
+[node name="VolumeControl" type="HSlider" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 
 [node name="Label2" type="Label" parent="MarginContainer/VBoxContainer"]
@@ -40,7 +40,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Resolution"
 
-[node name="ChangeResolution" type="OptionButton" parent="MarginContainer/VBoxContainer"]
+[node name="ChangeWindow" type="OptionButton" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 0
 item_count = 4
@@ -58,7 +58,7 @@ size_flags_horizontal = 8
 text = "Exit Settings Menu
 "
 
-[connection signal="value_changed" from="MarginContainer/VBoxContainer/Volume Control" to="." method="_on_h_slider_value_changed"]
+[connection signal="value_changed" from="MarginContainer/VBoxContainer/VolumeControl" to="." method="_on_h_slider_value_changed"]
 [connection signal="toggled" from="MarginContainer/VBoxContainer/Mute" to="." method="_on_mute_toggled"]
-[connection signal="item_selected" from="MarginContainer/VBoxContainer/ChangeResolution" to="." method="_on_change_resolution_item_selected"]
+[connection signal="item_selected" from="MarginContainer/VBoxContainer/ChangeWindow" to="." method="_on_change_resolution_item_selected"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/ExitSettings" to="." method="_on_exit_settings_pressed"]

--- a/new-game-project/Assets/Scripts/SettingsMenu.cs
+++ b/new-game-project/Assets/Scripts/SettingsMenu.cs
@@ -5,12 +5,16 @@ public partial class SettingsMenu : Control
 {
 	HSlider slide;
 	CheckBox check;
-	Button button;
+	OptionButton window;
 	float volume = 0;
-	bool muted = false;
+	ConfigFile config = new ConfigFile();
 
 
 	public override void _Ready() {
+		slide = GetNode<HSlider>("MarginContainer/VBoxContainer/VolumeControl");
+		check = GetNode<CheckBox>("MarginContainer/VBoxContainer/Mute");
+		window = GetNode<OptionButton>("MarginContainer/VBoxContainer/ChangeWindow");
+		LoadData();
 	}
 
 
@@ -23,6 +27,7 @@ public partial class SettingsMenu : Control
 		}
 		volume = value;
 		AudioServer.SetBusVolumeDb(0, value/3);
+		SaveData("VolumeLevel", (Variant)value);
 	}
 
 	public void _on_mute_toggled(bool toggled) {
@@ -34,6 +39,7 @@ public partial class SettingsMenu : Control
 		}
 
 		AudioServer.SetBusMute(0, toggled);
+		SaveData("MuteOption", (Variant)toggled);
 	}
 
 	public void _on_exit_settings_pressed() {
@@ -53,6 +59,22 @@ public partial class SettingsMenu : Control
 		else {
 			ChangeToBorderlessWindowed();
 		}
+		SaveData("WindowOption", (Variant)index);
+	}
+
+	public void SaveData(string dataToSave, Variant value) {
+		config.SetValue("Settings", dataToSave, value);
+		config.Save("res://settings.cfg");
+	}
+
+	public void LoadData() {
+		Error err = config.Load("res://settings.cfg");
+		if (err != Error.Ok) {
+    		return;
+		}	
+		slide.Value = (float)config.GetValue("Settings", "VolumeLevel");
+		check.ButtonPressed = (bool)config.GetValue("Settings", "MuteOption");
+		window.Selected = (int)config.GetValue("Settings", "WindowOption");
 	}
 
 	public void ChangeToFullScreen() {

--- a/new-game-project/settings.cfg
+++ b/new-game-project/settings.cfg
@@ -1,0 +1,5 @@
+[Settings]
+
+MuteOption=false
+VolumeLevel=18.0
+WindowOption=1


### PR DESCRIPTION
Be able to come back to settings with previous setting configurations saved. Ex: If game music mute button was toggled, when you go back to settings, it will still be toggled instead of being changed back to the default off value.